### PR TITLE
Add `exponentialRetry<S: Scheduler>(retries:withBackoff:scheduler:)` as a Combine extension

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,39 @@
 {
   "pins" : [
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "concurrencybooster",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftBoosterPack/ConcurrencyBooster.git",
       "state" : {
         "branch" : "main",
         "revision" : "7c6fd22685027e7500423cc0d8fffd3a3cf1a8c5"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/SwiftBoosterPack/ConcurrencyBooster.git", branch: "main")
+    .package(url: "https://github.com/SwiftBoosterPack/ConcurrencyBooster.git", branch: "main"),
+    .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
   ],
   targets: [
     .target(
@@ -28,7 +29,10 @@ let package = Package(
     ),
     .testTarget(
       name: "CombineExtensionsBoosterTests",
-      dependencies: ["CombineExtensionsBooster"],
+      dependencies: [
+        "CombineExtensionsBooster",
+        .product(name: "CombineSchedulers", package: "combine-schedulers"),
+      ],
       path: "SourceTests"
     ),
   ]

--- a/Source/Publisher+ExponentialRetry.swift
+++ b/Source/Publisher+ExponentialRetry.swift
@@ -1,0 +1,41 @@
+//
+//  Publisher+ExponentialRetry.swift
+//
+//
+//  Created by Mike Welsh on 2024-04-18.
+//
+
+import Combine
+import Foundation
+
+public extension Publisher {
+  /// Adds an exponential retry to the publisher, with an initial backoff. Runs on the specified scheduler. The final failure message is delayed by the backoff amount.
+  /// - Parameters:
+  ///   - retries: The number of retries before a failure occurs
+  ///   - initialBackoff: The initial backoff time to use on the publisher. Doubles on each retry attempt
+  ///   - scheduler: The scheduler to perform the delay on to wait
+  ///   - retryAction: An action to perform when the retry occurs. The retry action triggers _after_ the delay.
+  func exponentialRetry<S: Scheduler>(_ retries: Int,
+                                      withBackoff initialBackoff: S.SchedulerTimeType.Stride,
+                                      scheduler: S,
+                                      retryAction: @escaping () -> Void = {}) -> AnyPublisher<Output, Error> {
+      self
+      .tryCatch { error -> AnyPublisher<Output, Failure> in
+        var backOff = initialBackoff
+        return Just(Void())
+          .flatMap { _ -> AnyPublisher<Output, Failure> in
+            let result = Just(Void())
+              .delay(for: backOff, scheduler: scheduler)
+              .flatMap { _ in
+                retryAction()
+                return self
+              }
+            backOff = backOff * 2
+            return result.eraseToAnyPublisher()
+          }
+          .retry(retries - 1)
+          .eraseToAnyPublisher()
+      }
+      .eraseToAnyPublisher()
+  }
+}

--- a/SourceTests/Publisher+ExponentialRetryTests.swift
+++ b/SourceTests/Publisher+ExponentialRetryTests.swift
@@ -1,0 +1,164 @@
+//
+//  Publisher_ExponentialRetry.swift
+//  
+//
+//  Created by Mike Welsh on 2024-04-18.
+//
+
+import Combine
+import CombineSchedulers
+import Foundation
+import XCTest
+
+final class Publisher_ExponentialRetry: XCTestCase {
+  
+  func testExponentialRetryValueSentImmediately() {
+    var capturedValue = -1
+    var didFinish: Bool = false
+
+    let sut = PassthroughSubject<Int, Error>()
+    let testScheduler = DispatchQueue.test
+
+    // Must keep a reference to the cancellable otherwise the sink will not send values.
+    let cancellable = sut.exponentialRetry(3, withBackoff: 1, scheduler: testScheduler)
+      .sink(receiveCompletion: { completion in
+        switch completion {
+        case .failure:
+          XCTFail()
+        case .finished:
+          didFinish = true
+        }
+      }) { value in
+        capturedValue = value
+      }
+    
+    // Send a success and completion
+    XCTAssertFalse(didFinish)
+    XCTAssertEqual(-1, capturedValue)
+    sut.send(1)
+    sut.send(completion: .finished)
+    XCTAssertEqual(1, capturedValue)
+    XCTAssertTrue(didFinish)
+    cancellable.cancel()
+  }
+  
+  func testExponentialRetryValueSent() {
+    let errorCode = 10
+    var capturedValue = -1
+    var didFinish: Bool = false
+
+    let sut = PassthroughSubject<Int, Error>()
+    let testScheduler = DispatchQueue.test
+
+    // Must keep a reference to the cancellable otherwise the sink will not send values.
+    let cancellable = sut
+      .tryMap { value in
+        // Fail is the value is 10. A PassthroughSubject will not emit any more values if a failure is sent.
+        // So cause failures this way.
+        if value == errorCode {
+          throw NSError(domain: "combineextensionbooster", code: 10)
+        }
+        return value
+      }
+      .exponentialRetry(3, withBackoff: 1, scheduler: testScheduler)
+      .sink(receiveCompletion: { completion in
+        switch completion {
+        case .failure:
+          XCTFail()
+        case .finished:
+          didFinish = true
+        }
+      }) { value in
+        capturedValue = value
+      }
+
+    // Send an error
+    sut.send(errorCode)
+    // Advance one second
+    testScheduler.advance(by: 1)
+
+    // Send another failure and validate the exponential increase
+    sut.send(errorCode)
+    // With the exponential backoff, we must increase by 2 seconds.
+    testScheduler.advance(by: 2)
+    
+    // Send a success and completion
+    XCTAssertFalse(didFinish)
+    XCTAssertEqual(-1, capturedValue)
+    sut.send(1)
+    sut.send(completion: .finished)
+    XCTAssertEqual(1, capturedValue)
+    XCTAssertTrue(didFinish)
+    cancellable.cancel()
+  }
+
+  func testExponentialRetryEndsInFailure() {
+    let errorCode = 10
+    var capturedRetries = [Int]()
+    var capturedError: Error? = nil
+
+    let sut = PassthroughSubject<Int, Error>()
+    let testScheduler = DispatchQueue.test
+
+    // Must keep a reference to the cancellable otherwise the sink will not send values.
+    let cancellable = sut
+      .tryMap { value in
+        // Fail is the value is 10. A PassthroughSubject will not emit any more values if a failure is sent.
+        // So cause failures this way.
+        if value == errorCode {
+          throw NSError(domain: "combineextensionbooster", code: 10)
+        }
+        return value
+      }
+      .exponentialRetry(3, withBackoff: 1, scheduler: testScheduler, retryAction: { capturedRetries.append(1) })
+      .sink(receiveCompletion: { completion in
+        switch completion {
+        case .failure(let error):
+          capturedError = error
+        case .finished:
+          XCTFail()
+        }
+      }) { value in
+        
+      }
+
+    // No failure, no captured output.
+    XCTAssertTrue(capturedRetries.isEmpty)
+    // Send an error
+    sut.send(errorCode)
+    // No time incremented, so nothing captured yet.
+    XCTAssertTrue(capturedRetries.isEmpty)
+    // Advance one second
+    testScheduler.advance(by: 1)
+    XCTAssertEqual(capturedRetries.count, 1)
+
+    // Send another failure and validate the exponential increase
+    sut.send(errorCode)
+    XCTAssertEqual(capturedRetries.count, 1)
+    // With the exponential backoff, we must increase by 2 seconds so 1 second should do nothing.
+    testScheduler.advance(by: 1)
+    // Validate only one captured retry still.
+    XCTAssertEqual(capturedRetries.count, 1)
+    testScheduler.advance(by: 1)
+    // Now we should have two.
+    XCTAssertEqual(capturedRetries.count, 2)
+    XCTAssertNil(capturedError)
+
+    // Send another failure and validate the exponential increase
+    sut.send(errorCode)
+    XCTAssertEqual(capturedRetries.count, 2)
+    // With the exponential backoff, we must increase by 4 seconds now
+    testScheduler.advance(by: 4)
+    XCTAssertEqual(capturedRetries.count, 3)
+
+    // We have hit the retry limit - send another error which should result in capturing the error.
+    XCTAssertNil(capturedError)
+    sut.send(errorCode)
+    // The failure is delayed until the last scheduled delay.
+    testScheduler.advance(by: 8)
+    XCTAssertNotNil(capturedError)
+    // There is not another retry action after the final retry finishes.
+    XCTAssertEqual(capturedRetries.count, 3)
+    cancellable.cancel()
+  }
+}


### PR DESCRIPTION
- Allows specifying a retry with an exponential backoff on a scheduler for use in Combine